### PR TITLE
rework!: pixel shaders

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,100 +1,38 @@
 const std = @import("std");
 
-const GraphicsOption = enum {
-    None,
-    Native,
-    Metal,
-    OpenGL,
-    Vulkan,
-    D3D12,
-};
-
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const graphics = b.option(GraphicsOption, "graphics", "graphics framework to use") orelse .None;
-    const options = b.addOptions();
-    options.addOption(GraphicsOption, "GraphicsBackend", graphics);
 
-    const os_tag = target.os_tag orelse
-        b.host.target.os.tag;
+    const zig_objc = b.dependency("zig_objc", .{
+        .target = target,
+        .optimize = optimize,
+    });
 
-    const tests = switch (os_tag) {
-        .macos => blk: {
-            const zig_objc = b.dependency("zig_objc", .{
-                .target = target,
-                .optimize = optimize,
-            });
-            const cocoa = b.dependency("cocoa", .{
-                .target = target,
-                .optimize = optimize,
-            });
-
-            const dependencies: []const std.Build.ModuleDependency = &.{
-                .{
-                    .name = "zig-objc",
-                    .module = zig_objc.module("objc"),
-                },
-                .{
-                    .name = "cocoa",
-                    .module = cocoa.module("cocoa"),
-                },
-                .{
-                    .name = "GraphicsBackend",
-                    .module = options.createModule(),
-                },
-            };
-
-            _ = b.addModule("prism", .{
-                .source_file = .{
-                    .path = "src/main.zig",
-                },
-                .dependencies = dependencies,
-            });
-            const tests = b.addTest(.{
-                .root_source_file = .{ .path = "src/main.zig" },
-                .target = target,
-                .optimize = optimize,
-            });
-            const exe = b.addExecutable(.{
-                .name = "metal-test",
-                .root_source_file = .{ .path = "src/main.zig" },
-                .target = target,
-                .optimize = optimize,
-            });
-            for (dependencies) |dep| {
-                tests.addModule(dep.name, dep.module);
-                exe.addModule(dep.name, dep.module);
-            }
-            exe.linkFramework("Cocoa");
-            tests.linkFramework("Cocoa");
-            if (graphics == .Metal or graphics == .Native) {
-                tests.linkFramework("MetalKit");
-                tests.linkFramework("Metal");
-                exe.linkFramework("MetalKit");
-                exe.linkFramework("Metal");
-            }
-            tests.addOptions("GraphicsBackend", options);
-            exe.addOptions("GraphicsBackend", options);
-            b.installArtifact(exe);
-
-            break :blk tests;
-        },
-        else => blk: {
-            _ = b.addModule("prism", .{
-                .source_file = .{ .path = "src/main.zig" },
-            });
-            const tests = b.addTest(.{
-                .target = target,
-                .optimize = optimize,
-                .root_source_file = .{
-                    .path = "src/main.zig",
-                },
-            });
-            break :blk tests;
+    const dependencies: []const std.Build.ModuleDependency = &.{
+        .{
+            .name = "zig-objc",
+            .module = zig_objc.module("objc"),
         },
     };
+
+    _ = b.addModule("prism", .{
+        .source_file = .{
+            .path = "src/prism.zig",
+        },
+        .dependencies = dependencies,
+    });
+    const tests = b.addTest(.{
+        .root_source_file = .{ .path = "src/prism.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    for (dependencies) |dep| {
+        tests.addModule(dep.name, dep.module);
+    }
+    tests.linkFramework("Cocoa");
     b.installArtifact(tests);
+
     const run_tests = b.addRunArtifact(tests);
     const test_step = b.step("test", "run tests");
     test_step.dependOn(&run_tests.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,12 +4,8 @@
     .version = "0.0.0",
     .dependencies = .{
         .zig_objc = .{
-            .url = "https://github.com/mitchellh/zig-objc/archive/a38331cb6ee366b3f22d0068297810ef14c0c400.tar.gz",
-            .hash = "1220dcb34ec79a9b02c46372a41a446212f2366e7c69c8eba68e88f0f25b5ddf475d",
-        },
-        .cocoa = .{
-            .url = "https://github.com/rainbow-apps/cocoa.zig/archive/db36f2f65c2a570f90db3820474e499373813455.tar.gz",
-            .hash = "1220eda8aeb9da916c0193ecbcb6f1a6f66428ca49befc4b49d557f064728d42f450",
+            .url = "https://github.com/mitchellh/zig-objc/archive/10e552bd37c2f61b9f570d5ceb145165c6f1854b.tar.gz",
+            .hash = "122045926c2a90c61ca2ce907cc83a91ede0d49c989209fff2e2db421a88caf88e91",
         },
     },
 }

--- a/src/backend/cocoa.zig
+++ b/src/backend/cocoa.zig
@@ -1,0 +1,43 @@
+const prism = @import("../prism.zig");
+const cocoa = @import("cocoa/cocoa.zig");
+const builtin = @import("builtin");
+pub const Window = @import("cocoa/window.zig");
+pub const Layout = @import("cocoa/layout.zig");
+pub const Widget = @import("cocoa/widget.zig");
+
+// graphics implementations
+pub const Metal = @import("cocoa/metal.zig");
+pub const D3D12 = {
+    @compileLog(builtin.os.tag);
+    @compileError("D3D12 not supported for this target!");
+};
+pub const Vulkan = {
+    @compileLog(builtin.os.tag);
+    @compileError("Vulkan not implemented for this target!");
+};
+pub const OpenGL = {
+    @compileLog(builtin.os.tag);
+    @compileError("OpenGL not implemented for this target!");
+};
+
+/// creates objective-C classes used by the Cocoa prism backend
+/// also calls [NSapplication sharedApplication].
+pub fn init() prism.AppError!void {
+    try Window.init();
+    try Layout.init();
+    try Widget.init();
+    _ = cocoa.NSApp();
+}
+
+/// calls [NSApplication stop:nil]
+pub fn deinit() void {
+    cocoa.NSApp().msgSend(void, "stop:", .{cocoa.nil});
+}
+
+pub fn run() void {
+    cocoa.NSApp().msgSend(void, "run", .{});
+}
+
+pub fn stop() void {
+    cocoa.NSApp().msgSend(void, "stop:", .{cocoa.nil});
+}

--- a/src/backend/cocoa/cocoa.zig
+++ b/src/backend/cocoa/cocoa.zig
@@ -1,0 +1,100 @@
+const objc = @import("zig-objc");
+const std = @import("std");
+
+pub const YES = if (objc.c.BOOL == bool) true else @as(i8, 1);
+pub const NO = if (objc.c.BOOL == bool) false else @as(i8, 0);
+
+pub const nil = @as(objc.c.id, null);
+pub const Nil = @as(objc.c.Class, null);
+
+pub fn NSString(string: [:0]const u8) objc.Object {
+    const nsstring = objc.getClass("NSString").?;
+    return nsstring.msgSend(objc.Object, "stringWithUTF8String:", .{string.ptr});
+}
+
+pub fn alloc(class: anytype) objc.Object {
+    switch (@typeInfo(@TypeOf(class))) {
+        .Struct => return class.msgSend(objc.Object, "alloc", .{}),
+        .Pointer => return objc.getClass(class).?.msgSend(objc.Object, "alloc", .{}),
+        else => @compileError("expected class or string, got " ++ @tagName(@typeInfo(@TypeOf(class)))),
+    }
+}
+
+pub fn NSApp() objc.Object {
+    const NSApplication = objc.getClass("NSApplication").?;
+    return NSApplication.msgSend(objc.Object, "sharedApplication", .{});
+}
+
+pub const NSWindow = struct {
+    pub const StyleMask = packed struct {
+        titled: bool,
+        closable: bool,
+        miniaturizable: bool,
+        resizable: bool,
+        utility_window: bool = false,
+        _unused_1: bool = false,
+        doc_modal_window: bool = false,
+        nonactivating_panel: bool = false,
+        _unused_2: u4 = 0,
+        unified_title_and_toolbar: bool = false,
+        hud_window: bool = false,
+        fullscreen: bool = false,
+        fullsize_content_view: bool = false,
+        _padding: u48 = 0,
+
+        pub const default: StyleMask = .{
+            .titled = true,
+            .closable = true,
+            .miniaturizable = true,
+            .fullscreen = false,
+            .fullsize_content_view = true,
+            .resizable = true,
+        };
+
+        comptime {
+            std.debug.assert(@sizeOf(@This()) == @sizeOf(u64));
+            std.debug.assert(@bitSizeOf(@This()) == @bitSizeOf(u64));
+        }
+    };
+};
+
+pub const NSPoint = extern struct {
+    x: f64,
+    y: f64,
+
+    pub fn make(x: f64, y: f64) NSPoint {
+        return .{
+            .x = x,
+            .y = y,
+        };
+    }
+};
+
+pub const NSRange = extern struct {
+    location: u64,
+    length: u64,
+};
+
+pub const NSSize = extern struct {
+    width: f64,
+    height: f64,
+
+    pub fn make(w: f64, h: f64) NSSize {
+        return .{
+            .width = w,
+            .height = h,
+        };
+    }
+};
+
+pub const NSRect = extern struct {
+    origin: NSPoint,
+    size: NSSize,
+
+    pub fn make(x: f64, y: f64, w: f64, h: f64) NSRect {
+        return .{
+            .origin = .{ .x = x, .y = y },
+            .size = .{ .width = w, .height = h },
+        };
+    }
+};

--- a/src/backend/cocoa/layout.zig
+++ b/src/backend/cocoa/layout.zig
@@ -1,0 +1,203 @@
+const prism = @import("../../prism.zig");
+const cocoa = @import("cocoa.zig");
+const objc = @import("zig-objc");
+
+pub fn init() prism.AppError!void {
+    const PrismViewController = objc.allocateClassPair(
+        objc.getClass("NSObject") orelse return error.PlatformCodeFailed,
+        "PrismViewController",
+    ) orelse return error.PlatformCodeFailed;
+    defer objc.registerClassPair(PrismViewController);
+    if (!(PrismViewController.addMethod("initWithZigStruct:size:block:", initWithZigStruct) catch return error.PlatformCodeFailed))
+        return error.PlatformCodeFailed;
+    if (!(PrismViewController.addMethod("attemptResizeWithSize:init:", attemptResize) catch return error.PlatformCodeFailed))
+        return error.PlatformCodeFailed;
+    if (!PrismViewController.addIvar("data")) return error.PlatformCodeFailed;
+    if (!PrismViewController.addIvar("layoutSize")) return error.PlatformCodeFailed;
+    if (!PrismViewController.addIvar("layoutBlock")) return error.PlatformCodeFailed;
+    if (!PrismViewController.addIvar("view")) return error.PlatformCodeFailed;
+}
+
+pub fn create(options: prism.Layout.Options, children: anytype) prism.Layout.Error!prism.Layout {
+    const block = Block.init(.{}, (struct {
+        fn blockFn(
+            block_ptr: *const Block.Context,
+            self: objc.c.id,
+            new_size: cocoa.NSSize,
+            init_view: objc.c.BOOL,
+        ) callconv(.C) cocoa.NSSize {
+            _ = block_ptr;
+            const controller = objc.Object.fromId(self);
+            const size = controller.getInstanceVariable("layoutSize");
+            const current_size = size.msgSend(cocoa.NSRect, "sizeValue", .{});
+            const data = controller.getInstanceVariable("data")
+                .msgSend(*anyopaque, "bytes", .{});
+            const blk_options: *prism.Layout.Options = @ptrCast(@alignCast(data));
+
+            const actual_new_size: cocoa.NSSize = .{
+                .height = switch (blk_options.height) {
+                    .fraction => new_size.height,
+                    .pixels => |p| p,
+                },
+                .width = switch (blk_options.width) {
+                    .fraction => new_size.width,
+                    .pixels => |p| p,
+                },
+            };
+
+            switch (blk_options.kind) {
+                .Box => |box| {
+                    const width_trim: f64 = switch (box.margins.left) {
+                        .pixels => |p| p,
+                        .fraction => |f| actual_new_size.width * f,
+                    } + switch (box.margins.right) {
+                        .pixels => |p| p,
+                        .fraction => |f| actual_new_size * f,
+                    };
+                    const height_trim: f64 = switch (box.margins.top) {
+                        .pixels => |p| p,
+                        .fraction => |f| actual_new_size.height * f,
+                    } + switch (box.margins.bottom) {
+                        .pixels => |p| p,
+                        .fraction => |f| actual_new_size.height * f,
+                    };
+                    const child_size: cocoa.NSSize = .{
+                        .width = actual_new_size.width - width_trim,
+                        .height = actual_new_size.height - height_trim,
+                    };
+                    if (child_size.height < 0 or child_size.width < 0) return current_size;
+                    const child = controller.getProperty(objc.Object, "childViewControllers")
+                        .msgSend(objc.Object, "objectAtIndex:", .{@as(u64, 0)});
+                    const new_child_size = child.msgSend(cocoa.NSSize, "attemptResizeWithSize:init:", .{
+                        child_size, init_view,
+                    });
+                    const set_size_to: cocoa.NSSize = .{
+                        .width = new_child_size.width + width_trim,
+                        .height = new_child_size + height_trim,
+                    };
+                    if (init_view == cocoa.YES) {
+                        const view = cocoa.alloc("NSView")
+                            .msgSend(objc.Object, "initWithFrame:", .{
+                            cocoa.NSRect{
+                                .origin = .{ .x = 0, .y = 0 },
+                                .size = set_size_to,
+                            },
+                        });
+                        controller.setInstanceVariable("view", view);
+                        const child_view = child.getProperty(objc.Object, "view");
+                        view.msgSend(void, "addSubview:", .{child_view});
+                    } else {
+                        controller.getProperty(objc.Object, "view")
+                            .msgSend(void, "setFrameSize:", .{set_size_to});
+                    }
+                    const new_origin: cocoa.NSPoint = .{
+                        .x = switch (box.margins.left) {
+                            .pixels => |p| p,
+                            .fraction => |f| set_size_to.width * f,
+                        },
+                        .y = switch (box.margins.bottom) {
+                            .pixels => |p| p,
+                            .fraction => |f| set_size_to.height * f,
+                        },
+                    };
+                    const child_view = child.getProperty(objc.Object, "view");
+                    child_view.msgSend(void, "setFrameOrigin:", .{new_origin});
+                    child_view.setProperty("needsDisplay", .{cocoa.YES});
+                    size.msgSend(void, "release", .{});
+                    const ivar = objc.getClass("NSValue").?
+                        .msgSend(objc.Object, "valueWithSize:", .{set_size_to});
+                    controller.setInstanceVariable("layoutSize", ivar);
+                    return set_size_to;
+                },
+            }
+        }
+    }).blockFn) catch return error.PlatformCodeFailed;
+    const controller = cocoa.alloc("PrismViewController")
+        .msgSend(objc.Object, "initWithZigStruct:size:block:", .{
+        &options,
+        @sizeOf(prism.Layout.Options),
+        block.context,
+    });
+
+    const info = @typeInfo(@TypeOf(children));
+    comptime {
+        @import("std").debug.assert(info == .Struct);
+        @import("std").debug.assert(info.Struct.is_tuple);
+        if (options.kind == .Box) @import("std").debug.assert(info.Struct.fields.len == 1);
+        for (info.Struct.fields) |field| {
+            @import("std").debug.assert(field.type == prism.Layout or field.type == prism.Widget);
+        }
+    }
+    for (@typeInfo(@TypeOf(children)).Struct.fields) |field| {
+        const layout = @field(children, field.name);
+        const layout_id: objc.c.id = @ptrCast(@alignCast(layout.handle));
+        const layout_obj = objc.Object.fromId(layout_id);
+        controller.msgSend(void, "addChildViewController:", .{layout_obj});
+    }
+
+    return .{
+        .handle = controller.value,
+    };
+}
+
+pub fn destroy(self: prism.Layout) void {
+    const controller_id: objc.c.id = @ptrCast(@alignCast(self.handle));
+    const controller = objc.Object.fromId(controller_id);
+    const view = controller.getInstanceVariable("view");
+    view.msgSend(void, "release", .{});
+    controller.getInstanceVariable("data")
+        .msgSend(void, "release", .{});
+    const block: Block = .{
+        .context = @ptrCast(@alignCast(controller.getInstanceVariable("layoutBlock").value)),
+    };
+    block.deinit();
+    controller.msgSend(void, "release", .{});
+}
+
+pub const Block = objc.Block(
+    struct {},
+    .{ objc.c.id, cocoa.NSSize, objc.c.BOOL },
+    cocoa.NSSize,
+);
+
+fn initWithZigStruct(
+    target: objc.c.id,
+    sel: objc.c.SEL,
+    zig_struct: *anyopaque,
+    size: u64,
+    layout_block: objc.c.id,
+) callconv(.C) objc.c.id {
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const data = objc.getClass("NSData").?
+        .msgSend(objc.Object, "dataWithBytes:length:", .{
+        zig_struct,
+        size,
+    });
+    self.setInstanceVariable("data", data);
+    self.setInstanceVariable("layoutBlock", objc.Object.fromId(layout_block));
+    const layout_size = objc.getClass("NSValue").?
+        .msgSend(objc.Object, "valueWithSize:", .{
+        cocoa.NSSize{
+            .width = 0,
+            .height = 0,
+        },
+    });
+    self.setInstanceVariable("layoutSize", layout_size);
+    return self.value;
+}
+
+fn attemptResize(
+    target: objc.c.id,
+    sel: objc.c.SEL,
+    new_size: cocoa.NSSize,
+    init_view: objc.c.BOOL,
+) callconv(.C) cocoa.NSSize {
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const layout_block = self.getInstanceVariable("layoutBlock");
+    const block: Block = .{
+        .context = @ptrCast(@alignCast(layout_block.value)),
+    };
+    return block.invoke(.{ target, new_size, init_view });
+}

--- a/src/backend/cocoa/metal.zig
+++ b/src/backend/cocoa/metal.zig
@@ -1,0 +1,603 @@
+const prism = @import("../../prism.zig");
+const Layout = @import("layout.zig");
+const cocoa = @import("cocoa.zig");
+const objc = @import("zig-objc");
+
+const Graphics = prism.Graphics(.Metal);
+
+pub fn init() prism.AppError!Graphics {
+    try setup();
+    return .{
+        .handle = MTLCreateSystemDefaultDevice(),
+    };
+}
+
+pub fn create(device: Graphics) Graphics.RenderingContext {
+    const device_id: objc.c.id = @ptrCast(@alignCast(device.handle));
+    const mtkdevice = objc.Object.fromId(device_id);
+    return .{
+        .handle = mtkdevice.msgSend(objc.Object, "newCommandQueue", .{}).value,
+    };
+}
+
+pub fn destroy(self: Graphics.RenderingContext) void {
+    const command_queue_id: objc.c.id = @ptrCast(@alignCast(self.handle));
+    objc.Object.fromId(command_queue_id).msgSend(void, "release", .{});
+}
+
+pub const PixelShader = struct {
+    /// compiles a new pixel shader;
+    /// for the pixel shader API (uniforms, etc.),
+    /// see the doc comments in the main file.
+    /// errorPrinter will be called in the event that an error occurs during compilation.
+    /// if null, the error will be printed to stderr.
+    /// ctx is passed to errorPrinter.
+    pub fn define(
+        rendering_context: Graphics.RenderingContext,
+        source: [:0]const u8,
+        errorPrinter: ?*const fn (ctx: ?*anyopaque, error_str: [*:0]const u8) void,
+        ctx: ?*anyopaque,
+    ) Graphics.PixelShader.Err!Graphics.PixelShader {
+        const context_id: objc.c.id = @ptrCast(@alignCast(rendering_context.handle));
+        const commandQueue = objc.Object.fromId(context_id);
+        const device = commandQueue.getProperty(objc.Object, "device");
+        var error_obj: objc.c.id = undefined;
+        const library = library: {
+            const opts = cocoa.alloc("MTLCompileOptions")
+                .msgSend(objc.Object, "init", .{});
+            defer opts.msgSend(void, "release", .{});
+            const src_str = cocoa.NSString(source);
+            defer src_str.msgSend(void, "release", .{});
+            break :library device.msgSend(objc.Object, "newLibraryWithSource:options:error:", .{
+                src_str,
+                opts,
+                &error_obj,
+            });
+        };
+        defer library.msgSend(void, "release", .{});
+
+        if (error_obj != cocoa.nil) {
+            const error_str = objc.Object.fromId(error_obj);
+            defer error_str.msgSend(void, "release", .{});
+            const string = error_str.getProperty(objc.Object, "localizedDescription")
+                .getProperty([*:0]const u8, "UTF8String");
+            if (errorPrinter) |errFn| {
+                errFn(ctx, string);
+            } else {
+                @import("std").debug.print("{s}\n", .{string});
+            }
+            return error.CompilationFailed;
+        }
+
+        const vtxfn = cocoa.NSString("vertexFn");
+        defer vtxfn.msgSend(void, "release", .{});
+        const frgfn = cocoa.NSString("fragmentFn");
+        defer frgfn.msgSend(void, "release", .{});
+        const vertex_fn = library.msgSend(objc.Object, "newFunctionWithName:", .{vtxfn});
+        defer vertex_fn.msgSend(void, "release", .{});
+        const fragment_fn = library.msgSend(objc.Object, "newFunctionWithName:", .{frgfn});
+        defer fragment_fn.msgSend(void, "release", .{});
+
+        const descriptor = cocoa.alloc("MTLRenderPipelineDescriptor")
+            .msgSend(objc.Object, "init", .{});
+        defer descriptor.msgSend(void, "release", .{});
+        descriptor.msgSend(void, "reset", .{});
+        descriptor.setProperty("vertexFunction", .{vertex_fn});
+        descriptor.setProperty("fragmentFunction", .{fragment_fn});
+
+        const attachment = cocoa.alloc("MTLRenderPipelineColorAttachmentDescriptor")
+            .msgSend(objc.Object, "init", .{});
+        defer attachment.msgSend(void, "release", .{});
+        attachment.msgSend(void, "setPixelFormat:", .{@as(u64, 80)});
+        attachment.setProperty("blendingEnabled", .{cocoa.YES});
+        attachment.setProperty("destinationAlphaBlendFactor", .{@as(u64, 1)});
+
+        descriptor.getProperty(objc.Object, "colorAttachments")
+            .msgSend(void, "setObject:atIndexedSubscript:", .{
+            attachment,
+            @as(u64, 0),
+        });
+
+        var error_obj_2: objc.c.id = undefined;
+        const handle = device.msgSend(objc.Object, "newRenderPipelineStateWithDescriptor:error:", .{
+            descriptor,
+            &error_obj_2,
+        });
+
+        if (error_obj_2 != cocoa.nil) {
+            const error_str = objc.Object.fromId(error_obj);
+            defer error_str.msgSend(void, "release", .{});
+            const string = error_str.getProperty(objc.Object, "localizedDescription")
+                .getProperty([*:0]const u8, "UTF8String");
+            if (errorPrinter) |errFn| {
+                errFn(ctx, string);
+            } else {
+                @import("std").debug.print("{s}\n", .{string});
+            }
+            return error.CompilationFailed;
+        }
+
+        return .{
+            .handle = handle.value,
+        };
+    }
+
+    /// `new_data` must be a One pointer or a Slice and not null.
+    pub fn updateWidgetUserData(
+        self: Graphics.PixelShader,
+        widget_to_update: prism.Widget,
+        new_data: anytype,
+    ) void {
+        _ = self;
+        const type_info = @typeInfo(@TypeOf(new_data));
+        comptime {
+            @import("std").debug.assert(type_info == .Pointer);
+            @import("std").debug.assert(type_info.Pointer.size == .One or type_info.Pointer.size == .Slice);
+        }
+        const T = type_info.Pointer.child;
+        const id: objc.c.id = @ptrCast(@alignCast(widget_to_update.handle));
+        const prism_view = objc.Object.fromId(id).getInstanceVariable("view");
+        const delegate = prism_view.getInstanceVariable("context");
+        if (!@import("std").mem.eql(u8, delegate.getClassName(), "PrismPixelShaderDelegate")) return;
+        const userdata = delegate.getInstanceVariable("userData");
+        const buffer = userdata.msgSend(*anyopaque, "contents", .{});
+        switch (type_info.Pointer.size) {
+            .One => {
+                const data: *T = @ptrCast(@alignCast(buffer));
+                data.* = new_data.*;
+                const range: cocoa.NSRange = .{
+                    .location = 0,
+                    .length = @sizeOf(T),
+                };
+                userdata.msgSend(void, "didModifyRange:", .{range});
+            },
+            .Slice => {
+                const data: [*]T = @ptrCast(@alignCast(buffer));
+                @memcpy(data, new_data);
+                const range: cocoa.NSRange = .{
+                    .location = 0,
+                    .length = @sizeOf(T) * new_data.len,
+                };
+                userdata.msgSend(void, "didModifyRange:", .{range});
+            },
+            else => unreachable,
+        }
+    }
+
+    /// disposes the pixel shader's GPU representation.
+    pub fn dispose(self: Graphics.PixelShader) void {
+        const id: objc.c.id = @ptrCast(@alignCast(self.handle));
+        const obj = objc.Object.fromId(id);
+        obj.msgSend(void, "release", .{});
+    }
+
+    /// creates a widget that uses the pixel shader as its graphics.
+    /// `userdata_bytes`, if non-null,
+    /// must be either a single pointer or a slice and will be copied to the GPU;
+    /// it is up to the user to correctly define and use userdata_bytes in the shader.
+    pub fn widget(
+        self: Graphics.PixelShader,
+        context: Graphics.RenderingContext,
+        width: prism.Layout.Amount,
+        height: prism.Layout.Amount,
+        userdata_bytes: anytype,
+    ) prism.AppError!prism.Widget {
+        const type_info = @typeInfo(@TypeOf(userdata_bytes));
+        comptime {
+            const std = @import("std");
+            std.debug.assert(type_info == .Pointer or type_info == .Null);
+            if (type_info != .Null)
+                std.debug.assert(type_info.Pointer.size == .One or type_info.Pointer.size == .Slice);
+        }
+        const size: u64 = size: {
+            if (type_info == .Null) break :size 0;
+            break :size if (type_info.Pointer.size == .Slice)
+                userdata_bytes.len * @sizeOf(type_info.Pointer.child)
+            else
+                @sizeOf(type_info.Pointer.child);
+        };
+        const ptr: ?*anyopaque = userdata_bytes;
+        const pipeline_id: objc.c.id = @ptrCast(@alignCast(self.handle));
+        const pipeline = objc.Object.fromId(pipeline_id);
+        const device = pipeline.getProperty(objc.Object, "device");
+        const command_queue_id: objc.c.id = @ptrCast(@alignCast(context.handle));
+        const delegate = cocoa.alloc("PrismPixelShaderDelegate")
+            .msgSend(objc.Object, "initWithPipeline:context:", .{ pipeline, command_queue_id });
+
+        if (size > 0) {
+            const opts: ResourceOptions = .{
+                .cache_mode = .WriteCombined,
+                .storage_mode = .Managed,
+                .hazard_mode = .Default,
+            };
+            const buffer = device.msgSend(objc.Object, "newBufferWithBytes:length:options:", .{
+                ptr,
+                size,
+                @as(u64, @bitCast(opts)),
+            });
+            delegate.setInstanceVariable("userData", buffer);
+        }
+        const mouse_data: PixelShaderWidget.MouseData = .{
+            .x = 0,
+            .y = 0,
+            .left = false,
+            .right = false,
+            .other = false,
+            .present = false,
+        };
+        const opts: ResourceOptions = .{
+            .cache_mode = .WriteCombined,
+            .storage_mode = .Managed,
+            .hazard_mode = .Default,
+        };
+        const buffer = device.msgSend(objc.Object, "newBufferWithBytes:length:options:", .{
+            &mouse_data,
+            @as(u64, @sizeOf(PixelShaderWidget.MouseData)),
+            @as(u64, @bitCast(opts)),
+        });
+        delegate.setInstanceVariable("mouseData", buffer);
+
+        const options: prism.Widget.Options = .{
+            .width = width,
+            .height = height,
+            .click = PixelShaderWidget.click,
+            .drag = PixelShaderWidget.drag,
+            .hover = PixelShaderWidget.hover,
+            .context = delegate.value,
+            .presence = PixelShaderWidget.presence,
+            .other_teardown = PixelShaderWidget.teardown,
+            .draw = PixelShaderWidget.draw,
+            .resize_finished = PixelShaderWidget.resize_ended,
+        };
+        const block = Layout.Block.init(.{}, PixelShaderWidget.blockFn) catch return error.PlatformCodeFailed;
+        const widget_obj = cocoa.alloc("PrismViewController")
+            .msgSend(objc.Object, "initWithZigStruct:size:block:", .{ &options, @as(u64, @sizeOf(prism.Widget.Options)), block.context });
+        return .{ .handle = widget_obj.value };
+    }
+};
+
+const PixelShaderWidget = struct {
+    const MouseData = extern struct {
+        x: f32,
+        y: f32,
+        left: bool,
+        right: bool,
+        other: bool,
+        present: bool,
+    };
+
+    fn click(ctx: ?*anyopaque, x: f64, y: f64, button: prism.MouseButton, is_release: bool) bool {
+        const id: objc.c.id = @ptrCast(@alignCast(ctx orelse return true));
+        const delegate = objc.Object.fromId(id);
+        const data = delegate.getInstanceVariable("mouseData");
+        const mouse_data_ptr = data.msgSend(*anyopaque, "contents", .{});
+        const mouse_data: *MouseData = @ptrCast(@alignCast(mouse_data_ptr));
+        mouse_data.x = @floatCast(x);
+        mouse_data.y = @floatCast(y);
+        switch (button) {
+            .left => mouse_data.left = is_release,
+            .right => mouse_data.right = is_release,
+            .other => mouse_data.other = is_release,
+        }
+        const range: cocoa.NSRange = .{
+            .location = 0,
+            .length = @sizeOf(MouseData),
+        };
+        data.msgSend(void, "didModifyRange:", .{range});
+        return false;
+    }
+
+    fn hover(ctx: ?*anyopaque, x: f64, y: f64) bool {
+        const id: objc.c.id = @ptrCast(@alignCast(ctx orelse return true));
+        const delegate = objc.Object.fromId(id);
+        const data = delegate.getInstanceVariable("mouseData");
+        const mouse_data_ptr = data.msgSend(*anyopaque, "contents", .{});
+        const mouse_data: *MouseData = @ptrCast(@alignCast(mouse_data_ptr));
+        mouse_data.x = @floatCast(x);
+        mouse_data.y = @floatCast(y);
+        const range: cocoa.NSRange = .{
+            .location = 0,
+            .length = @sizeOf(MouseData),
+        };
+        data.msgSend(void, "didModifyRange:", .{range});
+        return false;
+    }
+
+    fn presence(ctx: ?*anyopaque, is_enter: bool) bool {
+        const id: objc.c.id = @ptrCast(@alignCast(ctx orelse return true));
+        const delegate = objc.Object.fromId(id);
+        const data = delegate.getInstanceVariable("mouseData");
+        const mouse_data_ptr = data.msgSend(*anyopaque, "bytes", .{});
+        const mouse_data: *MouseData = @ptrCast(@alignCast(mouse_data_ptr));
+        mouse_data.present = is_enter;
+        const range: cocoa.NSRange = .{
+            .location = 0,
+            .length = @sizeOf(MouseData),
+        };
+        data.msgSend(void, "didModifyRange:", .{range});
+        return false;
+    }
+
+    fn drag(ctx: ?*anyopaque, x: f64, y: f64, button: prism.MouseButton) bool {
+        _ = button;
+        return hover(ctx, x, y);
+    }
+
+    fn draw(self: *anyopaque) void {
+        const id: objc.c.id = @ptrCast(@alignCast(self));
+        const prism_view = objc.Object.fromId(id);
+        prism_view.getProperty(objc.Object, "subviews")
+            .msgSend(objc.Object, "objectAtIndex:", .{@as(u64, 0)})
+            .setProperty("needsDisplay", .{cocoa.YES});
+    }
+
+    fn teardown(self: *anyopaque) void {
+        const id: objc.c.id = @ptrCast(@alignCast(self));
+        const prism_view = objc.Object.fromId(id);
+        prism_view.getProperty(objc.Object, "subviews")
+            .msgSend(objc.Object, "objectAtIndex:", .{@as(u64, 0)})
+            .msgSend(void, "release", .{});
+    }
+
+    fn resize_ended(self: *anyopaque) void {
+        _ = self;
+    }
+
+    fn blockFn(
+        block_ptr: *const Layout.Block.Context,
+        self: objc.c.id,
+        new_size: cocoa.NSSize,
+        init_view: objc.c.BOOL,
+    ) callconv(.C) cocoa.NSSize {
+        _ = block_ptr;
+        const controller = objc.Object.fromId(self);
+        const opts = controller.getInstanceVariable("data")
+            .msgSend(*const anyopaque, "bytes", .{});
+        const options: *const prism.Widget.Options = @ptrCast(@alignCast(opts));
+        const actual_new_size: cocoa.NSSize = .{
+            .width = switch (options.width) {
+                .fraction => new_size.width,
+                .pixels => |p| p,
+            },
+            .height = switch (options.height) {
+                .fraction => new_size.height,
+                .pixels => |p| p,
+            },
+        };
+        const id: objc.c.id = @ptrCast(@alignCast(options.context.?));
+        const delegate = objc.Object.fromId(id);
+        const device = delegate.getInstanceVariable("pipeline")
+            .getProperty(objc.Object, "device");
+        if (init_view == cocoa.YES) {
+            const view = cocoa.alloc("PrismView")
+                .msgSend(objc.Object, "initWithZigStruct:size:frame:", .{
+                options, @as(u64, @sizeOf(prism.Widget.Options)),
+                cocoa.NSRect{
+                    .origin = .{ .x = 0, .y = 0 },
+                    .size = actual_new_size,
+                },
+            });
+            defer view.msgSend(void, "release", .{});
+            controller.setInstanceVariable("view", view);
+            const mtkview = cocoa.alloc("MTKView")
+                .msgSend(objc.Object, "initWithFrame:device:", .{
+                cocoa.NSRect{
+                    .origin = .{ .x = 0, .y = 0 },
+                    .size = actual_new_size,
+                },
+                device,
+            });
+            defer mtkview.msgSend(void, "release", .{});
+            view.msgSend(void, "addSubview:", .{mtkview});
+            mtkview.setProperty("delegate", .{delegate});
+
+            const drawable_size = mtkview.getProperty(cocoa.NSSize, "drawableSize");
+            const buffer = delegate.getInstanceVariable("feedbackTexture");
+
+            const descriptor = cocoa.alloc("MTLTextureDescriptor")
+                .msgSend(objc.Object, "init", .{});
+            defer descriptor.msgSend(void, "release", .{});
+            descriptor.setProperty("width", .{@as(u64, @intFromFloat(drawable_size.width))});
+            descriptor.setProperty("height", .{@as(u64, @intFromFloat(drawable_size.height))});
+            descriptor.msgSend(void, "setUsage:", .{@as(u64, 3)});
+            descriptor.msgSend(void, "setPixelFormat:", .{@as(u64, 115)});
+            const new_texture = device.msgSend(objc.Object, "newTextureWithDescriptor:", .{descriptor});
+
+            if (new_texture.value != cocoa.nil) {
+                delegate.setInstanceVariable("feedbackTexture", new_texture);
+                buffer.msgSend(void, "release", .{});
+            }
+        } else {
+            const view = controller.getInstanceVariable("view");
+            view.msgSend(void, "setFrameSize:", .{actual_new_size});
+            view.getProperty(objc.Object, "subviews")
+                .msgSend(objc.Object, "objectAtIndex:", .{@as(u64, 0)})
+                .msgSend(void, "setFrameSize:", .{actual_new_size});
+        }
+        const size = objc.getClass("NSValue").?
+            .msgSend(objc.Object, "valueWithSize:", .{actual_new_size});
+        controller.setInstanceVariable("layoutSize", size);
+        return actual_new_size;
+    }
+};
+
+extern "C" fn MTLCreateSystemDefaultDevice() objc.c.id;
+
+const MTLViewport = extern struct {
+    originX: f64,
+    originY: f64,
+    width: f64,
+    height: f64,
+    znear: f64,
+    zfar: f64,
+};
+
+fn setup() prism.AppError!void {
+    {
+        const PrismPixelShaderDelegate = objc.allocateClassPair(
+            objc.getClass("NSObject") orelse return error.PlatformCodeFailed,
+            "PrismPixelShaderDelegate",
+        ) orelse return error.PlatformCodeFailed;
+        defer objc.registerClassPair(PrismPixelShaderDelegate);
+        if (!(PrismPixelShaderDelegate.addMethod("drawInMTKView:", drawInMTKView) catch return error.PlatformCodeFailed))
+            return error.PlatformCodeFailed;
+        if (!(PrismPixelShaderDelegate.addMethod("mtkView:drawableSizeWillChange:", drawableSize) catch return error.PlatformCodeFailed))
+            return error.PlatformCodeFailed;
+        if (!(PrismPixelShaderDelegate.addMethod("initWithPipeline:context:", initWithPipeline) catch return error.PlatformCodeFailed))
+            return error.PlatformCodeFailed;
+        if (!PrismPixelShaderDelegate.addIvar("mouseData")) return error.PlatformCodeFailed;
+        if (!PrismPixelShaderDelegate.addIvar("pipeline")) return error.PlatformCodeFailed;
+        if (!PrismPixelShaderDelegate.addIvar("context")) return error.PlatformCodeFailed;
+        if (!PrismPixelShaderDelegate.addIvar("userData")) return error.PlatformCodeFailed;
+        if (!PrismPixelShaderDelegate.addIvar("currentFrameNumber")) return error.PlatformCodeFailed;
+        if (!PrismPixelShaderDelegate.addIvar("feedbackTexture")) return error.PlatformCodeFailed;
+    }
+}
+
+fn initWithPipeline(
+    target: objc.c.id,
+    sel: objc.c.SEL,
+    pipeline: objc.c.id,
+    context: objc.c.id,
+) callconv(.C) objc.c.id {
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const pipeline_obj = objc.Object.fromId(pipeline);
+    const context_obj = objc.Object.fromId(context);
+    self.setInstanceVariable("pipeline", pipeline_obj);
+    self.setInstanceVariable("context", context_obj);
+    self.setInstanceVariable(
+        "currentFrameNumber",
+        objc.getClass("NSNumber").?
+            .msgSend(objc.Object, "numberWithUnsignedLong:", .{@as(u32, 0)}),
+    );
+    return self.value;
+}
+
+fn drawInMTKView(target: objc.c.id, sel: objc.c.SEL, view_id: objc.c.id) callconv(.C) void {
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const pipeline = self.getInstanceVariable("pipeline");
+    const context = self.getInstanceVariable("context");
+    const view = objc.Object.fromId(view_id);
+    const buffer = context.msgSend(objc.Object, "commandBuffer", .{});
+    const descriptor = view.getProperty(objc.Object, "currentRenderPassDescriptor");
+    const encoder = buffer.msgSend(objc.Object, "renderCommandEncoderWithDescriptor:", .{descriptor});
+    const size = view.getProperty(cocoa.NSSize, "drawableSize");
+    encoder.setProperty("viewport", .{
+        MTLViewport{
+            .originX = 0,
+            .originY = 0,
+            .width = size.width,
+            .height = size.height,
+            .znear = 0,
+            .zfar = 1,
+        },
+    });
+
+    const frame = self.getInstanceVariable("currentFrameNumber");
+    const val = frame.getProperty(u32, "unsignedLongValue");
+    const size_and_frame: SizeAndFrame = .{
+        .width = @floatCast(size.width),
+        .height = @floatCast(size.height),
+        .frame = val,
+    };
+
+    encoder.setProperty("renderPipelineState", .{pipeline});
+    const full_frame: [6][2]f32 = .{
+        .{ -1, -1 }, .{ -1, 1 }, .{ 1, 1 },
+        .{ -1, -1 }, .{ 1, -1 }, .{ 1, 1 },
+    };
+    encoder.msgSend(void, "setVertexBytes:length:atIndex:", .{
+        @as([*]const u8, @ptrCast(&full_frame)),
+        @as(u64, @sizeOf(@TypeOf(full_frame))),
+        @as(u64, 0),
+    });
+    encoder.msgSend(void, "setFragmentTexture:atIndex:", .{
+        self.getInstanceVariable("feedbackTexture"),
+        @as(u64, 0),
+    });
+    encoder.msgSend(void, "setFragmentBytes:length:atIndex:", .{
+        @as([*]const u8, @ptrCast(&size_and_frame)),
+        @as(u64, @sizeOf(SizeAndFrame)),
+        @as(u64, 0),
+    });
+    encoder.msgSend(void, "setFragmentBuffer:offset:atIndex:", .{
+        self.getInstanceVariable("mouseData"),
+        @as(u64, 0),
+        @as(u64, 1),
+    });
+    encoder.msgSend(void, "setFragmentBuffer:offset:atIndex:", .{
+        self.getInstanceVariable("userData"),
+        @as(u64, 0),
+        @as(u64, 2),
+    });
+    encoder.msgSend(void, "drawPrimitives:vertexStart:vertexCount:", .{
+        @as(u64, 3),
+        @as(u64, 0),
+        @as(u64, 6),
+    });
+
+    buffer.msgSend(void, "presentDrawable:", .{
+        view.getProperty(objc.Object, "currentDrawable"),
+    });
+    encoder.msgSend(void, "endEncoding", .{});
+    buffer.msgSend(void, "commit", .{});
+
+    frame.msgSend(void, "release", .{});
+    self.setInstanceVariable(
+        "currentFrameNumber",
+        objc.getClass("NSNumber").?
+            .msgSend(objc.Object, "numberWithUnsignedLong:", .{val + 1}),
+    );
+}
+
+fn drawableSize(
+    target: objc.c.id,
+    sel: objc.c.SEL,
+    view_id: objc.c.id,
+    size: cocoa.NSSize,
+) callconv(.C) void {
+    _ = sel;
+    const delegate = objc.Object.fromId(target);
+    const mtkview = objc.Object.fromId(view_id);
+    const device = mtkview.getProperty(objc.Object, "device");
+    const buffer = delegate.getInstanceVariable("feedbackTexture");
+
+    const descriptor = cocoa.alloc("MTLTextureDescriptor")
+        .msgSend(objc.Object, "init", .{});
+    defer descriptor.msgSend(void, "release", .{});
+    descriptor.setProperty("width", .{@as(u64, @intFromFloat(size.width))});
+    descriptor.setProperty("height", .{@as(u64, @intFromFloat(size.height))});
+    descriptor.msgSend(void, "setUsage:", .{@as(u64, 3)});
+    descriptor.msgSend(void, "setPixelFormat:", .{@as(u64, 115)});
+    const new_texture = device.msgSend(objc.Object, "newTextureWithDescriptor:", .{descriptor});
+
+    if (new_texture.value != cocoa.nil) {
+        delegate.setInstanceVariable("feedbackTexture", new_texture);
+        buffer.msgSend(void, "release", .{});
+    }
+}
+
+const ResourceOptions = packed struct(u64) {
+    cache_mode: enum(u1) {
+        Default,
+        WriteCombined,
+    },
+    _unused: u3 = 0,
+    storage_mode: enum(u2) { Shared, Managed, Private, Memoryless },
+    _unused_2: u2 = 0,
+    hazard_mode: enum(u2) {
+        Default,
+        Untracked,
+        Tracked,
+        _unused,
+    },
+    _padding: u54 = 0,
+};
+
+const SizeAndFrame = extern struct {
+    width: f32,
+    height: f32,
+    frame: u32,
+};

--- a/src/backend/cocoa/widget.zig
+++ b/src/backend/cocoa/widget.zig
@@ -1,0 +1,234 @@
+const prism = @import("../../prism.zig");
+const cocoa = @import("cocoa.zig");
+const objc = @import("zig-objc");
+
+pub fn init() prism.AppError!void {
+    const PrismView = objc.allocateClassPair(
+        objc.getClass("NSView") orelse return error.PlatformCodeFailed,
+        "PrismView",
+    ) orelse return error.PlatformCodeFailed;
+    defer objc.registerClassPair(PrismView);
+    if (!(PrismView.addMethod("initWithZigStruct:size:frame:", initWithZigStruct) catch return error.PlatformCodeFailed))
+        return error.PlatformCodeFailed;
+    PrismView.replaceMethod("mouseMoved:", mouseMoved);
+    PrismView.replaceMethod("mouseDown:", mouseClicked);
+    PrismView.replaceMethod("rightMouseDown:", mouseClicked);
+    PrismView.replaceMethod("otherMouseDown:", mouseClicked);
+    PrismView.replaceMethod("mouseUp:", mouseClicked);
+    PrismView.replaceMethod("rightMouseUp:", mouseClicked);
+    PrismView.replaceMethod("otherMouseUp:", mouseClicked);
+    PrismView.replaceMethod("mouseDragged:", mouseDragged);
+    PrismView.replaceMethod("rightMouseDragged:", mouseDragged);
+    PrismView.replaceMethod("otherMouseDragged:", mouseDragged);
+    PrismView.replaceMethod("mouseEntered:", mousePresence);
+    PrismView.replaceMethod("mouseExited:", mousePresence);
+    PrismView.replaceMethod("drawRect:", draw);
+    PrismView.replaceMethod("viewDidEndLiveResize", resizeEnded);
+    PrismView.replaceMethod("acceptsFirstResponder", acceptsFirstResponder);
+    if (!PrismView.addIvar("options")) return error.PlatformCodeFailed;
+    if (!PrismView.addIvar("context")) return error.PlatformCodeFailed;
+}
+
+pub fn destroy(self: prism.Widget) void {
+    const self_id: objc.c.id = @ptrCast(@alignCast(self.handle));
+    const widget = objc.Object.fromId(self_id);
+    const opts = widget.getInstanceVariable("options");
+    defer opts.msgSend(void, "release", .{});
+    const opts_ptr = opts.msgSend(*anyopaque, "bytes", .{});
+    const options: *prism.Widget.Options = @ptrCast(@alignCast(opts_ptr));
+    const ctx = widget.getInstanceVariable("context");
+    defer ctx.msgSend(void, "release", .{});
+    if (options.other_teardown) |teardown| {
+        teardown(widget.value);
+    }
+    widget.msgSend(void, "release", .{});
+}
+
+fn initWithZigStruct(
+    target: objc.c.id,
+    sel: objc.c.SEL,
+    zig_struct: *const anyopaque,
+    size: u64,
+    frame: cocoa.NSRect,
+) callconv(.C) objc.c.id {
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const ptr: *const prism.Widget.Options = @ptrCast(@alignCast(zig_struct));
+    const data = objc.getClass("NSData").?
+        .msgSend(objc.Object, "dataWithBytes:length:", .{
+            ptr,
+            size,
+    });
+    self.setInstanceVariable("options", data);
+
+    const ctxt: objc.c.id = if (ptr.context) |ctx| @ptrCast(@alignCast(ctx)) else cocoa.nil;
+    self.setInstanceVariable("context", .{ .value = ctxt });
+
+    self.msgSendSuper(objc.getClass("NSView").?, void, "initWithFrame:", .{frame});
+    
+    return self.value;
+}
+
+fn acceptsFirstResponder(target: objc.c.id, sel: objc.c.SEL) callconv(.C) objc.c.BOOL {
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const data = self.getInstanceVariable("data")
+        .msgSend(?*anyopaque, "bytes", .{});
+    const opts: *prism.Widget.Options = @ptrCast(@alignCast(data orelse return cocoa.YES));
+    if (opts.click != null or opts.drag != null or opts.hover != null or opts.presence != null) return cocoa.YES;
+    return cocoa.NO;
+}
+
+fn mouseMoved(target: objc.c.id, sel: objc.c.SEL, event_id: objc.c.id) callconv(.C) void {
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const opts_ptr = self.getInstanceVariable("options")
+        .msgSend(*anyopaque, "bytes", .{});
+    const opts: *prism.Widget.Options = @ptrCast(@alignCast(opts_ptr));
+    if (opts.hover) |hover| {
+        const context = self.getInstanceVariable("context");
+        const ptr = context.value orelse null;
+
+        const event = objc.Object.fromId(event_id);
+        const pt = event.getProperty(cocoa.NSPoint, "locationInWindow");
+        const coord = self.msgSend(cocoa.NSPoint, "convertPoint:fromView:", .{
+            pt,
+            cocoa.nil,
+        });
+        if (hover(ptr, coord.x, coord.y)) {
+            const next = self.getProperty(objc.Object, "nextResponder");
+            next.msgSend(void, "mouseMoved:", .{event});
+        }
+    } else {
+        const next = self.getProperty(objc.Object, "nextResponder");
+        next.msgSend(void, "mouseMoved:", .{event_id});
+    }
+}
+
+fn mousePresence(target: objc.c.id, sel: objc.c.SEL, event_id: objc.c.id) callconv(.C) void {
+    const self = objc.Object.fromId(target);
+    const opts_ptr = self.getInstanceVariable("options")
+        .msgSend(*anyopaque, "bytes", .{});
+    const opts: *prism.Widget.Options = @ptrCast(@alignCast(opts_ptr));
+    const name = objc.Sel.getName(.{ .value = sel });
+    if (opts.presence) |presence| {
+        const context = self.getInstanceVariable("context");
+        const ptr: ?*anyopaque = context.value orelse null;
+
+        const is_enter = @import("std").mem.eql(u8, name, "mouseEntered:");
+
+        if (presence(ptr, is_enter)) {
+            const next = self.getProperty(objc.Object, "nextResponder");
+            next.msgSend(void, name, .{event_id});
+        }
+    } else {
+        const next = self.getProperty(objc.Object, "nextResponder");
+        next.msgSend(void, name, .{event_id});
+    }
+}
+
+fn mouseClicked(target: objc.c.id, sel: objc.c.SEL, event_id: objc.c.id) callconv(.C) void {
+    const Sel: objc.Sel = .{
+        .value = sel,
+    };
+    const self = objc.Object.fromId(target);
+    const opts_ptr = self.getInstanceVariable("options")
+        .msgSend(*anyopaque, "bytes", .{});
+    const opts: *prism.Widget.Options = @ptrCast(@alignCast(opts_ptr));
+    if (opts.click) |click| {
+        const context = self.getInstanceVariable("context");
+        const ptr: ?*anyopaque = context.value orelse null;
+
+        const name = objc.Sel.getName(.{ .value = sel });
+        const button: prism.MouseButton, const is_release = blk: {
+            if (@import("std").mem.eql(u8, name, "mouseDown:"))
+                break :blk .{ .left, false };
+            if (@import("std").mem.eql(u8, name, "rightMouseDown:"))
+                break :blk .{ .right, false };
+            if (@import("std").mem.eql(u8, name, "otherMouseDown:"))
+                break :blk .{ .other, false };
+            if (@import("std").mem.eql(u8, name, "mouseUp:"))
+                break :blk .{ .left, true };
+            if (@import("std").mem.eql(u8, name, "rightMouseUp:"))
+                break :blk .{ .right, true };
+            if (@import("std").mem.eql(u8, name, "otherMouseUp:"))
+                break :blk .{ .other, true };
+            unreachable;
+        };
+
+        const event = objc.Object.fromId(event_id);
+        const pt = event.getProperty(cocoa.NSPoint, "locationInWindow");
+        const coord = self.msgSend(cocoa.NSPoint, "convertPoint:fromView:", .{
+            pt,
+            cocoa.nil,
+        });
+
+        if (click(ptr, coord.x, coord.y, button, is_release)) {
+            const next = self.getProperty(objc.Object, "nextResponder");
+            next.msgSend(void, Sel, .{event_id});
+        }
+    } else {
+        const next = self.getProperty(objc.Object, "nextResponder");
+        next.msgSend(void, Sel, .{event_id});
+    }
+}
+
+fn mouseDragged(target: objc.c.id, sel: objc.c.SEL, event_id: objc.c.id) callconv(.C) void {
+    const Sel: objc.Sel = .{ .value = sel };
+    const self = objc.Object.fromId(target);
+    const opts_ptr = self.getInstanceVariable("options")
+        .msgSend(*anyopaque, "bytes", .{});
+    const opts: *prism.Widget.Options = @ptrCast(@alignCast(opts_ptr));
+    if (opts.drag) |drag| {
+        const context = self.getInstanceVariable("context");
+        const ptr: ?*anyopaque = context.value orelse null;
+
+        const name = objc.Sel.getName(.{ .value = sel });
+        const button: prism.MouseButton = blk: {
+            if (@import("std").mem.eql(u8, name, "mouseDragged:"))
+                break :blk .left;
+            if (@import("std").mem.eql(u8, name, "rightMouseDragged:"))
+                break :blk .right;
+            if (@import("std").mem.eql(u8, name, "otherMouseDragged:"))
+                break :blk .other;
+            unreachable;
+        };
+
+        const event = objc.Object.fromId(event_id);
+        const pt = event.getProperty(cocoa.NSPoint, "locationInWindow");
+        const coord = self.msgSend(cocoa.NSPoint, "convertPoint:fromView:", .{
+            pt,
+            cocoa.nil,
+        });
+
+        if (drag(ptr, coord.x, coord.y, button)) {
+            const next = self.getProperty(objc.Object, "nextResponder");
+            next.msgSend(void, Sel, .{event_id});
+        }
+    } else {
+        const next = self.getProperty(objc.Object, "nextResponder");
+        next.msgSend(void, Sel, .{event_id});
+    }
+}
+
+fn draw(target: objc.c.id, sel: objc.c.SEL, rect: cocoa.NSRect) callconv(.C) void {
+    _ = sel;
+    _ = rect;
+
+    const self = objc.Object.fromId(target);
+    const opts_ptr = self.getInstanceVariable("options")
+        .msgSend(*const anyopaque, "bytes", .{});
+    const opts: *const prism.Widget.Options = @ptrCast(@alignCast(opts_ptr));
+    opts.draw(self.value);
+}
+
+fn resizeEnded(target: objc.c.id, sel: objc.c.SEL) callconv(.C) void {
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const opts_ptr = self.getInstanceVariable("options")
+        .msgSend(*const anyopaque, "bytes", .{});
+    const opts: *const prism.Widget.Options = @ptrCast(@alignCast(opts_ptr));
+    if (opts.resize_finished) |f| f(self.value);
+    self.msgSendSuper(objc.getClass("NSView").?, void, "viewDidEndLiveResize", .{});
+}
+    

--- a/src/backend/cocoa/window.zig
+++ b/src/backend/cocoa/window.zig
@@ -1,0 +1,180 @@
+const prism = @import("../../prism.zig");
+const cocoa = @import("cocoa.zig");
+const objc = @import("zig-objc");
+
+/// uses prism.Window.Options to create a window
+/// under the hood creates an instance of a subclass of NSWindowController;
+/// the returned handle is an objective-C `id` corresponding to this window controller
+pub fn create(options: prism.Window.Options) prism.AppError!prism.Window {
+    const window = cocoa.alloc("PrismWindowController")
+        .msgSend(objc.Object, "initWithZigStruct:", .{&options});
+    return .{
+        .handle = window.value,
+    };
+}
+
+/// destroys a window; closing and releasing it.
+pub fn destroy(self: prism.Window) void {
+    const window_controller_id: objc.c.id = @ptrCast(@alignCast(self.handle));
+    const window_controller = objc.Object.fromId(window_controller_id);
+    const window = window_controller.getProperty(objc.Object, "window");
+    window.msgSend(void, "performClose:", .{cocoa.nil});
+    window_controller.msgSend(void, "release", .{});
+}
+
+/// replaces the window's content with the given layout
+pub fn setContent(self: prism.Window, layout: anytype) void {
+    comptime {
+        @import("std").debug.assert(@TypeOf(layout) == prism.Layout or @TypeOf(layout) == prism.Widget);
+    }
+    const window_controller_id: objc.c.id = @ptrCast(@alignCast(self.handle));
+    const window_controller = objc.Object.fromId(window_controller_id);
+    const window = window_controller.getProperty(objc.Object, "window");
+    const frame = window.getProperty(cocoa.NSRect, "frame");
+    const controller_id: objc.c.id = @ptrCast(@alignCast(layout.handle));
+    const controller = objc.Object.fromId(controller_id);
+    const new_size = controller.msgSend(cocoa.NSSize, "attemptResizeWithSize:init:", .{ frame.size, cocoa.YES });
+    const view = controller.getInstanceVariable("view");
+    window.setProperty("contentView", .{view});
+    window_controller.setInstanceVariable("viewController", controller);
+    window.msgSend(void, "setContentSize:", .{new_size});
+}
+
+pub fn init() prism.AppError!void {
+    const PrismWindowController = objc.allocateClassPair(
+        objc.getClass("NSWindowController") orelse return error.PlatformCodeFailed,
+        "PrismWindowController",
+    ) orelse return error.PlatformCodeFailed;
+    defer objc.registerClassPair(PrismWindowController);
+    if (!(PrismWindowController.addMethod("initWithZigStruct:", initWithZigStruct) catch return error.PlatformCodeFailed))
+        return error.PlatformCodeFailed;
+    if (!PrismWindowController.addIvar("options"))
+        return error.PlatformCodeFailed;
+    if (!PrismWindowController.addIvar("exit_on_close"))
+        return error.PlatformCodeFailed;
+    if (!PrismWindowController.addIvar("window_title"))
+        return error.PlatformCodeFailed;
+    if (!PrismWindowController.addIvar("viewController"))
+        return error.PlatformCodeFailed;
+    PrismWindowController.replaceMethod("loadWindow", loadWindow);
+    if (!(PrismWindowController.addMethod("windowShouldClose:", windowShouldClose) catch return error.PlatformCodeFailed))
+        return error.PlatformCodeFailed;
+    if (!(PrismWindowController.addMethod("windowWillResize:toSize:", windowWillResize) catch return error.PlatformCodeFailed))
+        return error.PlatformCodeFailed;
+}
+
+fn windowShouldClose(target: objc.c.id, sel: objc.c.SEL, sender: objc.c.id) callconv(.C) objc.c.BOOL {
+    _ = sender;
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const exit_on_close = self.getInstanceVariable("exit_on_close")
+        .msgSend(objc.c.BOOL, "boolValue", .{});
+    if (exit_on_close == cocoa.YES) {
+        cocoa.NSApp().msgSend(void, "terminate:", .{self});
+    }
+    return cocoa.YES;
+}
+
+fn windowWillResize(target: objc.c.id, sel: objc.c.SEL, sender: objc.c.id, size: cocoa.NSSize) callconv(.C) cocoa.NSSize {
+    _ = sender;
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const controller = self.getInstanceVariable("viewController");
+    const new_size = controller.msgSend(cocoa.NSSize, "attemptResizeWithSize:init:", .{
+        size, cocoa.NO,
+    });
+    return new_size;
+}
+
+fn loadWindow(target: objc.c.id, sel: objc.c.SEL) callconv(.C) void {
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const data = self.getInstanceVariable("options");
+    const ptr = data.msgSend(*anyopaque, "bytes", .{});
+    const options: *prism.Window.Options = @ptrCast(@alignCast(ptr));
+    defer data.msgSend(void, "release", .{});
+    const title = self.getInstanceVariable("window_title");
+    defer title.msgSend(void, "release", .{});
+
+    const rect = cocoa.NSRect.make(
+        options.position.x,
+        options.position.y,
+        options.size.width,
+        options.size.height,
+    );
+    const stylemask: cocoa.NSWindow.StyleMask = .{
+        .closable = options.closable,
+        .miniaturizable = options.miniaturizable,
+        .resizable = options.resizable,
+        .titled = title.value != null,
+    };
+    const window = cocoa.alloc("NSWindow")
+        .msgSend(objc.Object, "initWithContentRect:styleMask:backing:defer:", .{
+        rect,
+        stylemask,
+        @as(u64, 2),
+        cocoa.NO,
+    });
+    defer window.msgSend(void, "release", .{});
+    window.setProperty("delegate", .{self});
+    self.setProperty("window", .{window});
+    window.setProperty("isVisible", .{cocoa.YES});
+    if (title.value) |_| window.setProperty("title", .{title});
+}
+
+fn initWithZigStruct(
+    target: objc.c.id,
+    sel: objc.c.SEL,
+    zig_struct: *anyopaque,
+) callconv(.C) objc.c.id {
+    _ = sel;
+    const self = objc.Object.fromId(target);
+    const options: *prism.Window.Options = @ptrCast(@alignCast(zig_struct));
+    if (options.title) |title|
+        self.setInstanceVariable("window_title", cocoa.NSString(title));
+    const data = objc.getClass("NSData").?
+        .msgSend(objc.Object, "dataWithBytes:length:", .{
+        zig_struct,
+        @as(u64, @sizeOf(prism.Window.Options)),
+    });
+    const exit_on_close = objc.getClass("NSNumber").?
+        .msgSend(objc.Object, "numberWithBool:", .{
+        if (options.exit_on_close) cocoa.YES else cocoa.NO,
+    });
+    self.setInstanceVariable("exit_on_close", exit_on_close);
+    self.setInstanceVariable("options", data);
+    self.msgSend(void, "loadWindow", .{});
+    const window = self.getProperty(objc.Object, "window");
+    self.msgSendSuper(
+        objc.getClass("NSWindowController").?,
+        void,
+        "initWithWindow:",
+        .{window},
+    );
+
+    return self.value;
+}
+
+test "create and destroy" {
+    const std = @import("std");
+    try init();
+    _ = cocoa.NSApp();
+    const title = try std.testing.allocator.dupeZ(u8, "title");
+    const window = try create(.{
+        .title = title,
+        .size = .{
+            .width = 400,
+            .height = 200,
+        },
+        .exit_on_close = true,
+    });
+    std.testing.allocator.free(title);
+    const pid = try std.Thread.spawn(.{}, struct {
+        fn runFn(win: prism.Window) void {
+            std.time.sleep(std.time.ns_per_s);
+            destroy(win);
+        }
+    }.runFn, .{window});
+    cocoa.NSApp().msgSend(void, "run", .{});
+    pid.join();
+}

--- a/src/backend/gtk.zig
+++ b/src/backend/gtk.zig
@@ -1,0 +1,9 @@
+const prism = @import("../prism.zig");
+
+pub fn init() prism.AppError!void {
+    @compileError("not implemented!");
+}
+
+pub fn deinit() void {
+    @compileError("not implemented!");
+}

--- a/src/backend/win32.zig
+++ b/src/backend/win32.zig
@@ -1,0 +1,9 @@
+const prism = @import("../prism.zig");
+
+pub fn init() prism.AppError!void {
+    @compileError("not implemented!");
+}
+
+pub fn deinit() void {
+    @compileError("not implemented!");
+}

--- a/src/prism.zig
+++ b/src/prism.zig
@@ -1,0 +1,234 @@
+const builtin = @import("builtin");
+
+const Cocoa = Prism(@import("backend/cocoa.zig"));
+const Gtk = Prism(@import("backend/gtk.zig"));
+const Win32 = Prism(@import("backend/win32.zig"));
+
+pub usingnamespace switch (builtin.os.tag) {
+    .linux => Gtk,
+    .macos => Cocoa,
+    .windows => Win32,
+    else => {
+        @compileLog(builtin.os);
+        @compileError("no default backend for this target!");
+    },
+};
+
+pub const GraphicsBackend = enum {
+    Metal,
+    OpenGL,
+    D3D12,
+    Vulkan,
+    Native,
+};
+
+fn Prism(comptime T: type) type {
+    return struct {
+
+        // core setup
+
+        /// sets up the prism backend.
+        /// must be called before other prism code runs.
+        /// must be called on the main thread.
+        pub const init = T.init;
+
+        /// stops the prism backend.
+        pub const deinit = T.deinit;
+
+        pub const run = T.run;
+        pub const stop = T.stop;
+
+        // setup error
+        pub const AppError = error{
+            PlatformCodeFailed,
+        };
+
+        // core types
+        pub const Window = struct {
+            /// opaque pointer to backend-specific representation of the window
+            handle: *anyopaque,
+
+            pub const Options = struct {
+                /// null makes the window untitled
+                title: ?[:0]const u8 = "",
+                closable: bool = true,
+                miniaturizable: bool = true,
+                resizable: bool = true,
+                exit_on_close: bool = false,
+                size: struct {
+                    width: f64,
+                    height: f64,
+                },
+                position: struct {
+                    x: f64,
+                    y: f64,
+                } = .{ .x = 100, .y = 100 },
+            };
+
+            /// creates a window
+            pub const create = T.Window.create;
+            /// destroys a window
+            pub const destroy = T.Window.destroy;
+            /// sets the window's content
+            pub const setContent = T.Window.setContent;
+        };
+        // pub const Loop = T.Loop;
+        pub const Layout = struct {
+            /// opaque pointer to backend-specific representation of the layout
+            handle: *anyopaque,
+
+            pub const Error = error{BadConstraints} || AppError;
+
+            /// creates a layout object with specified options and children
+            pub const create = T.Layout.create;
+            pub const destroy = T.Layout.destroy;
+
+            pub const desiredDimensions = T.Layout.desiredDimensions;
+
+            pub const Options = struct {
+                width: Amount,
+                height: Amount,
+                kind: union(Kind) {
+                    Box: struct {
+                        margins: struct {
+                            left: Amount,
+                            right: Amount,
+                            top: Amount,
+                            bottom: Amount,
+                        },
+                    },
+                },
+                const Kind = enum {
+                    Box,
+                };
+            };
+            /// for specifying sizes in either absolute (pixels) or relative (fraction) terms
+            pub const Amount = union(enum) {
+                pixels: f64,
+                fraction: f64,
+            };
+        };
+        pub const Widget = struct {
+            /// opaque pointer to backend-specific representation of the widget
+            handle: *anyopaque,
+
+            pub const toLayout = T.Widget.toLayout;
+            pub const destroy = T.Widget.destroy;
+
+            pub const Options = struct {
+                context: ?*anyopaque,
+                width: Layout.Amount,
+                height: Layout.Amount,
+                draw: *const DrawFn,
+                hover: ?*const HoverFn,
+                presence: ?*const PresenceFn,
+                click: ?*const ClickFn,
+                drag: ?*const DragFn,
+                other_teardown: ?*const OtherFn,
+                resize_finished: ?*const OtherFn,
+            };
+
+            pub const DrawFn = fn (self: *anyopaque) void;
+            pub const HoverFn = fn (ctx: ?*anyopaque, x: f64, y: f64) bool;
+            pub const PresenceFn = fn (ctx: ?*anyopaque, is_enter: bool) bool;
+            pub const ClickFn = fn (ctx: ?*anyopaque, x: f64, y: f64, button: MouseButton, is_release: bool) bool;
+            pub const DragFn = fn (ctx: ?*anyopaque, x: f64, y: f64, button: MouseButton) bool;
+            pub const OtherFn = fn (self: *anyopaque) void;
+            // key
+        };
+
+        const This = @This();
+        pub fn Graphics(comptime backend: GraphicsBackend) type {
+            const G = switch (backend) {
+                .D3D12 => T.D3D12,
+                .Metal => T.Metal,
+                .Vulkan => T.Vulkan,
+                .OpenGL => T.OpenGL,
+                .Native => {
+                    switch (builtin.os.tag) {
+                        .macos => return This.Graphics(.Metal),
+                        .linux => return This.Graphics(.Vulkan),
+                        .windows => return This.Graphics(.D3D12),
+                        else => {
+                            @compileLog(builtin.os.tag);
+                            @compileError("no default graphics backend for this target!");
+                        },
+                    }
+                },
+            };
+            return struct {
+                /// opaque pointer to backend-specific representation of GPU device.
+                handle: *anyopaque,
+
+                pub const Backend = backend;
+
+                /// call before using any methods in this struct.
+                /// should be called on the main thread
+                pub const init = G.init;
+
+                pub const RenderingContext = struct {
+                    /// opaque pointer to backend-specific representation of rendering context
+                    handle: *anyopaque,
+
+                    /// creates a rendering context
+                    pub const create = G.create;
+                    /// destroys a rendering context
+                    pub const destroy = G.destroy;
+                };
+
+                pub const PixelShader = struct {
+                    /// opaque pointer to graphics-backend-specific representation of pixel shader
+                    handle: *anyopaque,
+
+                    pub const Err = error{CompilationFailed};
+
+                    pub const Options = struct {
+                        size: struct {
+                            width: Layout.Amount,
+                            height: Layout.Amount,
+                        },
+                    };
+
+                    /// defines a pixel shader
+                    pub const define = G.PixelShader.define;
+                    /// destroys a pixel shader's GPU representation
+                    pub const dispose = G.PixelShader.dispose;
+                    /// creates a Widget from a pixel shader object
+                    pub const widget = G.PixelShader.widget;
+                    /// updates user data for given widget
+                    /// the passed widget must have been created from a PixelShader
+                    /// by calling `widget`.
+                    pub const updateWidgetUserData = G.PixelShader.updateWidgetUserData;
+
+                    test {
+                        @import("std").testing.refAllDeclsRecursive(@This());
+                    }
+                };
+            };
+        }
+
+        pub const MouseButton = enum { left, right, other };
+
+        test {
+            @import("std").testing.refAllDeclsRecursive(@This());
+        }
+    };
+}
+
+test {
+    switch (builtin.os.tag) {
+        .linux => {
+            _ = Gtk.Graphics(.Native);
+            _ = Gtk;
+        },
+        .macos => _ = {
+            _ = Cocoa.Graphics(.Native);
+            _ = Cocoa;
+        },
+        .windows => {
+            _ = Win32.Graphics(.Native);
+            _ = Win32;
+        },
+        else => {},
+    }
+}


### PR DESCRIPTION
this is the beginning of a reimagining. at the moment, only works on macOS using Metal for the graphics backend. the one feature implemented is the creation of (essentially fairly arbitrary) pixel shaders, which must be written in MSL, are aware of the mouse, and allow a user-defined buffer input, mouse state, and a feedback-capable texture.

the pixel shader vertex function must be named "vertexFn" and the fragment function must be named "fragmentFn". the current frame size and frame number are available as `buffer(0)` and should be declared in the shader code as

```metal
struct frameData
{
  float w;
  float h;
  uint32_t frame;
};
```

the mouse data is available as `buffer(1)` and should be declared in the shader code as

```metal
struct mouseData
{
  float x;
  float y;
  bool left;
  bool right;
  bool other;
  bool present;
};
```

NB: currently mouse hovering is broken (i need to add an NSTrackingArea to each PrismView that asks for it), so to get mouse movement to register it is necessary to click and/or drag.

user data is available as `buffer(2)`, and is untested. obviously it is your responsibility to make sure that the data you pass in makes sense with the data type you declare in the shader code.

a read/write capable texture of the same size as the entire frame is available as `texture(0)`. here is an example of accessing it every frame and writing to it every tenth frame.

```metal
struct Frame
{
  float width;
  float height;
  uint32_t frame;
};

vertex float4 vertexFn(uint vertexID [[vertex_id]],
  constant float2 *positions [[buffer(0)]])
{
  float4 out = float4(0.0, 0.0, 0.0, 1.0);
  out.xy = positions[vertexID].xy;
  return out;
}

fragment float4 fragmentFn(float4 in [[position]],
  texture2d<float, access::read_write> txt [[raster_order_group(0),
  texture(0)]], constant Frame &frame [[buffer(0)]])
{
  float2 size = float2(frame.width, frame.height);
  uint32_t frame_nr = frame.frame;
  // normalized coordinates
  float2 pixel_coord = (2.0 * in.xy - size) / size.y;
  ushort2 texcoord = (ushort2)(in.xy);

  float4 txtr_val = txt.read(texcoord);

  float4 out = float4(0.0, 0.0, 0.0, 1.0);
  // do stuff here

  if ((frame_nr % 10) == 0)
  {
    txt.write(out, texcoord);
  }
  return out;
}
```

aside from pixel shaders, supports basic window creation and starting and stopping the app.